### PR TITLE
Licensing mods

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,6 @@ canonifyURLs = false
 
 disqusShortname = "locallyoptimistic"
 googleAnalytics = "UA-345857-22"
-copyright = "© The text of this post is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License (CC BY-NC-ND 4.0). Images (including the LocallyOptimistic logo) are the property of LocallyOptimistic and should NOT be copied, reproduced, or remixed without explicit prior approval from LocallyOptimistic. See our licensing page (locallyoptimistic.com/licensing) for more information." 
 
 ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
 

--- a/content/licensing.md
+++ b/content/licensing.md
@@ -6,9 +6,12 @@ menu: "main"
 weight: 50
 ---
 
-The *text* of posts published on locallyoptimistic.com are licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License (CC BY-NC-ND 4.0).
+<a style="text-decoration:none" rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">
+  <img alt="Creative Commons License" style="float: left; border-width:0; margin: 1rem 1rem 0 0; box-shadow:none;" src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" />
+</a>
+The *text* of posts published on locallyoptimistic.com are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.
 
-Images (including the LocallyOptimistic logo) are the property of LocallyOptimistic and should NOT be copied, reproduced, or remixed without explicit prior approval from LocallyOptimistic. 
+Post illustrations, and the LocallyOptimistic logos are the property of LocallyOptimistic and should NOT be copied, reproduced, or remixed without explicit prior approval from LocallyOptimistic. 
 
-Authors retain ultimate ownership and copyright over the content they produce. They may distribute and re-license that content as they see fit. However, by publishing content on LocallyOptimistic, authors irrevocably grant LocallyOptimistic the right to continue to host, publish, and share that content in perpetuity.
+Authors retain ultimate ownership and copyright over the content (text and figures) they produce. They may distribute and re-license that content as they see fit. However, by publishing content on LocallyOptimistic, authors irrevocably grant LocallyOptimistic the right to continue to host, publish, and share that content in perpetuity.
 

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -19,14 +19,19 @@
         {{ end }}
       </ul>
       {{ end }}
-      <p class="post-copyright">
-        {{ if .Site.Copyright }}{{ .Site.Copyright }}{{ end }}{{ if gt (div (sub now.Unix .Lastmod.Unix) 86400) 100 }}This post was published <strong>{{ div (sub now.Unix .Lastmod.Unix) 86400 }}</strong> days ago, content in the post may be inaccurate, even wrong now, please take risk yourself.{{ end }}
-      </p>
     </footer>
     {{ if ne .Params.comments false }}
       {{ if .Site.DisqusShortname }}{{ template "_internal/disqus.html" . }}
       {{ else }}{{ end }}
     {{ end }}
+      <p class="post-copyright">
+        <a style="text-decoration:none" rel="license" href="/licensing/">
+          <img alt="Creative Commons License"
+            style="margin:10px 4px 0 0"
+            src="https://i.creativecommons.org/l/by-nc-nd/4.0/80x15.png" />
+        </a>
+        Locally Optimistic content is published under a <a href="/licensing/">CC BY-NC-ND 4.0</a> license.
+      </p>
   </section>
   {{ partial "footer.html" . }}
 {{ end }}

--- a/static/css/locally_optimistic.css
+++ b/static/css/locally_optimistic.css
@@ -79,7 +79,7 @@ a.logo {
 
 .post-detail #disqus_thread {
   clear:both;
-  padding-top:3rem;
+  padding-top:1rem;
 }
 
 


### PR DESCRIPTION
- moved the licensing content from `config.toml` into layout templates, specifically `single.html`
- made some changes around which images we're referring to on the licensing page
- added CC's icons to licensing page and footer
- made footer text brief and linked to licensing page

On /licensing :
<img width="844" alt="screen shot 2018-06-09 at 12 59 14 pm" src="https://user-images.githubusercontent.com/658203/41194157-4356f846-6be5-11e8-834c-9a9c75f0f990.png">

In post footers:
<img width="668" alt="screen shot 2018-06-09 at 12 59 33 pm" src="https://user-images.githubusercontent.com/658203/41194158-4579b55a-6be5-11e8-90d1-17f7d90b0409.png">
