### PR TITLE
Adds "Getting involved" page to promote our slack community

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -3,6 +3,7 @@ title: "About"
 date: "2018-02-05"
 layout: "about"
 menu: "main"
+comments: false
 weight: 50
 ---
 

--- a/content/code_of_conduct.md
+++ b/content/code_of_conduct.md
@@ -1,12 +1,19 @@
-# LocallyOptimistic Code of Conduct
+---
+title: "Code of Conduct"
+date: "2018-06-10"
+layout: "about"
+comments: false
+weight: 50
+---
 
 The LocallyOptimistic community is an inclusive community of current and future analytics leaders. We are committed to promoting diversity and providing an inclusive and safe environment for all of our community members.
 
-We do not tolerate harassment in any form. If you believe someone is violating the LocallyOptimistic Code of Conduct (or, generally doing anything that makes you feel uncomfortable), please [send our admin team an email](mailto:kaminsky.michael@gmail.com).
+We do not tolerate harassment in any form. If you believe someone is violating the LocallyOptimistic Code of Conduct (or, generally doing anything that makes you feel uncomfortable), please [send our admin team an email](mailto:admin@locallyoptimistic.com).
 
 LocallyOptimistic community members strive to be friendly, patient, and welcoming. We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to, members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 
 We expect everyone to:
+
 * Be considerate
 * Be respectful
 * Participate in good faith

--- a/content/community.md
+++ b/content/community.md
@@ -1,29 +1,41 @@
-# Welcome to Locally Optimistic
+---
+title: "Getting Involved"
+date: "2018-06-10"
+layout: "about"
+menu: "main"
+comments: false
+weight: 50
+---
 
-We are thrilled you have decided to join us.
+## Joining the Community
 
-If you have not already, please [reach out](mailto:kaminsky.michael@gmail.com) to ask for an invite to our slack group. 
+We are thrilled you have decided to join us. We have a growing [slack community](locallyoptimistic.slack.com) where current and aspiring analytics leaders discuss and share lessons and challenges from their experience working with data.
+
+If you have not already, please [reach out](mailto:contact@locallyoptimistic.com) to ask for an invite to our slack group. 
 
 Once you have received your invite, please do the following:
+
+* Read our [code of conduct]({{< relref "code_of_conduct.md" >}})
 * Use your full name in your slack handle (this community will work best if we are all real humans)
 * Add a profile photo
-* Read our [code of conduct](./code_of_conduct.md)
 * Introduce yourself in the #general channel
 
 In slack, remember that channels are free. If you want to start a conversation on a topic that doesn't have a channel dedicated to it, you can create a channel and invite others to join you.
 
-## Blog Authors and Contributors
+## Contributing to the Blog
 
 We are very excited to publish blog posts from current and future analytics leaders on [LocallyOptimistic](www.locallyoptimistic.com).
 
 A few ground rules:
+
 * The editorial team at LocallyOptimistic has the final word on what content gets posted. We reserve the right to reject any post for any reason at any time.
 * We do not publish posts that are designed to promote a specific product or service.
 * We do not compensate authors.
 * We do not take compensation for publishing (no payola).
 
-If you have an idea for a post you would like to write, reach out to Michael Kaminsky or Scott Breitenother on slack, and we will add you to our authors channel where we collaborate on preparing posts for publication. 
+If you have an idea for a post you would like to write, reach out to someone from [the editorial team]({{< relref "about.md" >}}) on slack, and we will add you to our authors channel where we collaborate on preparing posts for publication. 
 
+* First, review our [licensing]({{<relref "licensing.md" >}}) policies and make sure you're okay with licensing your content under our rules.
 * In order to contribute, we will need your github account so we can add you as a collaborator on [the repository](https://github.com/locallyoptimistic/LocallyOptimistic).
 * To contribute, you should submit a pull request with your content and ask for a review in the #authors channel. The editorial team at LocallyOptimistic will review your post, and will likely request changes. 
 * Once you have made all of the requested changes, we will determine where in the [post schedule](https://github.com/locallyoptimistic/LocallyOptimistic/wiki/Schedule) your content makes the most sense, and will set a publish date. (Note: we may re-schedule your post if we need to in order to ensure a good mix of content and authors.)

--- a/content/community.md
+++ b/content/community.md
@@ -9,7 +9,7 @@ weight: 50
 
 ## Joining the Community
 
-We are thrilled you have decided to join us. We have a growing [slack community](locallyoptimistic.slack.com) where current and aspiring analytics leaders discuss and share lessons and challenges from their experience working with data.
+We are thrilled you have decided to join our community. We have a growing [slack community](https://locallyoptimistic.slack.com) where current and aspiring analytics leaders discuss and share lessons and challenges from their experience working with data.
 
 If you have not already, please [reach out](mailto:contact@locallyoptimistic.com) to ask for an invite to our slack group. 
 
@@ -33,7 +33,7 @@ A few ground rules:
 * We do not compensate authors.
 * We do not take compensation for publishing (no payola).
 
-If you have an idea for a post you would like to write, reach out to someone from [the editorial team]({{< relref "about.md" >}}) on slack, and we will add you to our authors channel where we collaborate on preparing posts for publication. 
+If you have an idea for a post you would like to write, reach out to someone from [the editorial team]({{< relref "about.md" >}}) on slack, and we will add you to our #authors channel where we collaborate on preparing posts for publication. 
 
 * First, review our [licensing]({{<relref "licensing.md" >}}) policies and make sure you're okay with licensing your content under our rules.
 * In order to contribute, we will need your github account so we can add you as a collaborator on [the repository](https://github.com/locallyoptimistic/LocallyOptimistic).

--- a/content/licensing.md
+++ b/content/licensing.md
@@ -2,7 +2,7 @@
 title: "Licensing"
 date: "2018-06-07"
 layout: "about"
-menu: "main"
+comments: false
 weight: 50
 ---
 
@@ -14,4 +14,6 @@ The *text* of posts published on locallyoptimistic.com are licensed under a <a r
 Post illustrations, and the LocallyOptimistic logos are the property of LocallyOptimistic and should NOT be copied, reproduced, or remixed without explicit prior approval from LocallyOptimistic. 
 
 Authors retain ultimate ownership and copyright over the content (text and figures) they produce. They may distribute and re-license that content as they see fit. However, by publishing content on LocallyOptimistic, authors irrevocably grant LocallyOptimistic the right to continue to host, publish, and share that content in perpetuity.
+
+If you have questions about sharing or re-using content, please contact us at [contact@locallyoptimistic.com](mailto:contact@locallyoptimistic.com).
 

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -30,7 +30,7 @@
             style="margin:10px 4px 0 0"
             src="https://i.creativecommons.org/l/by-nc-nd/4.0/80x15.png" />
         </a>
-        Locally Optimistic content is published under a <a href="/licensing/">CC BY-NC-ND 4.0</a> license.
+        Locally Optimistic content is published under a CC BY-NC-ND 4.0 license. See our <a href="/licensing/">licensing page</a> for more details.
       </p>
   </section>
   {{ partial "footer.html" . }}


### PR DESCRIPTION
* Removes licensing page link from homepage, and makes the link more
explicit in the footer.
* Removes comments from non-post pages
* Publishes code-of-conduct